### PR TITLE
Profiled PID for controlling the rotation of targeting commands

### DIFF
--- a/src/main/kotlin/com/team4099/robot2023/commands/drivetrain/TargetSpeakerCommand.kt
+++ b/src/main/kotlin/com/team4099/robot2023/commands/drivetrain/TargetSpeakerCommand.kt
@@ -12,7 +12,8 @@ import edu.wpi.first.math.filter.MedianFilter
 import edu.wpi.first.wpilibj.RobotBase
 import edu.wpi.first.wpilibj2.command.Command
 import org.littletonrobotics.junction.Logger
-import org.team4099.lib.controller.PIDController
+import org.team4099.lib.controller.ProfiledPIDController
+import org.team4099.lib.controller.TrapezoidProfile
 import org.team4099.lib.units.Velocity
 import org.team4099.lib.units.base.inMeters
 import org.team4099.lib.units.derived.Radian
@@ -40,7 +41,7 @@ class TargetSpeakerCommand(
   val drivetrain: Drivetrain,
   val vision: Vision
 ) : Command() {
-  private var thetaPID: PIDController<Radian, Velocity<Radian>>
+  private var thetaPID: ProfiledPIDController<Radian, Velocity<Radian>>
   val thetakP =
     LoggedTunableValue(
       "Pathfollow/thetaAmpkP",
@@ -70,10 +71,13 @@ class TargetSpeakerCommand(
     addRequirements(drivetrain)
 
     thetaPID =
-      PIDController(
+      ProfiledPIDController(
         thetakP.get(),
         thetakI.get(),
         thetakD.get(),
+        TrapezoidProfile.Constraints(
+          DrivetrainConstants.STEERING_VEL_MAX, DrivetrainConstants.STEERING_ACCEL_MAX
+        )
       )
 
     if (!(RobotBase.isSimulation())) {
@@ -83,10 +87,13 @@ class TargetSpeakerCommand(
       thetakD.initDefault(DrivetrainConstants.PID.TELEOP_ALIGN_PID_KD)
 
       thetaPID =
-        PIDController(
+        ProfiledPIDController(
           DrivetrainConstants.PID.TELEOP_ALIGN_PID_KP,
           DrivetrainConstants.PID.TELEOP_ALIGN_PID_KI,
-          DrivetrainConstants.PID.TELEOP_ALIGN_PID_KD
+          DrivetrainConstants.PID.TELEOP_ALIGN_PID_KD,
+          TrapezoidProfile.Constraints(
+            DrivetrainConstants.STEERING_VEL_MAX, DrivetrainConstants.STEERING_ACCEL_MAX
+          )
         )
     } else {
       thetakP.initDefault(DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KP)
@@ -94,10 +101,13 @@ class TargetSpeakerCommand(
       thetakD.initDefault(DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KD)
 
       thetaPID =
-        PIDController(
+        ProfiledPIDController(
           DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KP,
           DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KI,
-          DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KD
+          DrivetrainConstants.PID.SIM_AUTO_THETA_PID_KD,
+          TrapezoidProfile.Constraints(
+            DrivetrainConstants.STEERING_VEL_MAX, DrivetrainConstants.STEERING_ACCEL_MAX
+          )
         )
     }
 
@@ -105,7 +115,7 @@ class TargetSpeakerCommand(
   }
 
   override fun initialize() {
-    thetaPID.reset() // maybe do first for x?
+    thetaPID.reset(0.degrees) // maybe do first for x?
     angleMedianFilter.reset()
     /*
     if (thetakP.hasChanged() || thetakI.hasChanged() || thetakD.hasChanged()) {

--- a/src/main/kotlin/com/team4099/robot2023/config/ControlBoard.kt
+++ b/src/main/kotlin/com/team4099/robot2023/config/ControlBoard.kt
@@ -69,7 +69,7 @@ object ControlBoard {
   val climbAlignLeft = Trigger { driver.dPadLeft }
   val climbAlignRight = Trigger { driver.dPadRight }
 
-  val targetSpeaker = Trigger { driver.xButton } // TODO: switch back to climbAlignLeft
+  val targetSpeaker = Trigger { driver.xButton }
   val climbAutoAlign = Trigger { driver.bButton }
 
   // week0 controls


### PR DESCRIPTION
Uses the `ProfiledPIDController` for all targeting commands in regards to the rotation. Using a profiled PID controller helps us account for larger amounts of error and adjust accordingly, while adhering to our constraints. The controller was changed to a profiled PID controller for the `TargetSpeakerCommand`, `TargetAngleCommand`, and `TargetNoteCommand`.